### PR TITLE
Remove all references to Substrait-unrelated subprojects.

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -99,16 +99,3 @@ jobs:
     - name: Run lit tests
       run: |
         cmake --build ${STRUCTURED_MAIN_BINARY_DIR} --target check-structured
-
-    - name: Run benchmarks
-      shell: bash # This enables the `-eo pipefail` flag to propagate script failures.
-      run: |
-        ${GITHUB_WORKSPACE}/sandbox/benchmarks/inner_product/run.sh test | tee /tmp/result.jsonl
-        ${GITHUB_WORKSPACE}/sandbox/benchmarks/inner_product/plot.sh -i /tmp/result.jsonl
-
-    - name: Archive benchmark plots
-      uses: actions/upload-artifact@v3
-      with:
-        name: structured-benchmark-plots
-        path: |
-          sandbox/benchmarks/**/*.pdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ add_subdirectory(third_party)
 ################################################################################
 add_custom_target(structured-all)
 
-add_subdirectory(examples)
 add_subdirectory(lib)
 add_subdirectory(include)
 add_subdirectory(python)

--- a/include/structured-c/Dialects.h
+++ b/include/structured-c/Dialects.h
@@ -17,18 +17,6 @@ extern "C" {
 #endif
 
 //===----------------------------------------------------------------------===//
-// Iterators dialect and types
-//===----------------------------------------------------------------------===//
-
-MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Iterators, iterators);
-
-MLIR_CAPI_EXPORTED
-bool mlirTypeIsAIteratorsStreamType(MlirType type);
-
-MLIR_CAPI_EXPORTED
-MlirType mlirIteratorsStreamTypeGet(MlirContext context, MlirType elementType);
-
-//===----------------------------------------------------------------------===//
 // Substrait dialect
 //===----------------------------------------------------------------------===//
 
@@ -56,37 +44,6 @@ MlirModule mlirSubstraitImportPlan(MlirContext context, MlirStringRef input,
 MLIR_CAPI_EXPORTED
 MlirAttribute mlirSubstraitExportPlan(MlirOperation op,
                                       MlirSubstraitSerdeFormat format);
-
-//===----------------------------------------------------------------------===//
-// Tabular dialect and types
-//===----------------------------------------------------------------------===//
-
-MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Tabular, tabular);
-
-/// Checks whether the given type is a tabular view type.
-MLIR_CAPI_EXPORTED bool mlirTypeIsATabularView(MlirType type);
-
-/// Creates a tabular view type that consists of the given list of column types.
-/// The type is owned by the context.
-MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGet(MlirContext ctx,
-                                                   intptr_t numColumns,
-                                                   MlirType const *columnTypes);
-
-/// Returns the number of column types contained in a tabular view.
-MLIR_CAPI_EXPORTED intptr_t mlirTabularViewTypeGetNumColumnTypes(MlirType type);
-
-/// Returns the pos-th column type in the tabular view type.
-MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetColumnType(MlirType type,
-                                                             intptr_t pos);
-
-/// Returns tuple type that represents one row of the given tabular view.
-MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetRowType(MlirType type);
-
-//===----------------------------------------------------------------------===//
-// Tuple dialect and attributes
-//===----------------------------------------------------------------------===//
-
-MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Tuple, tuple);
 
 #ifdef __cplusplus
 }

--- a/include/structured/CMakeLists.txt
+++ b/include/structured/CMakeLists.txt
@@ -1,2 +1,1 @@
-add_subdirectory(Conversion)
 add_subdirectory(Dialect)

--- a/include/structured/Dialect/CMakeLists.txt
+++ b/include/structured/Dialect/CMakeLists.txt
@@ -1,4 +1,1 @@
-add_subdirectory(Iterators)
 add_subdirectory(Substrait)
-add_subdirectory(Tabular)
-add_subdirectory(Tuple)

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,19 +1,9 @@
 add_mlir_public_c_api_library(StructuredCAPI
     Dialects.cpp
-    Passes.cpp
-    Transforms.cpp
 
   LINK_LIBS PUBLIC
     MLIRCAPIIR
-    MLIRIterators
-    MLIRIteratorsToLLVM
-    MLIRIteratorsTransforms
     MLIRSubstraitDialect
-    MLIRTabular
-    MLIRTabularToLLVM
     MLIRTargetSubstraitPB
-    MLIRTupleDialect
-    MLIRTupleTransforms
     MLIRPass
-    MLIRStatesToLLVM
 )

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -14,33 +14,13 @@
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
 #include "mlir/IR/Types.h"
-#include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Substrait/IR/Substrait.h"
-#include "structured/Dialect/Tabular/IR/Tabular.h"
-#include "structured/Dialect/Tuple/IR/Tuple.h"
 #include "structured/Target/SubstraitPB/Export.h"
 #include "structured/Target/SubstraitPB/Import.h"
 #include "structured/Target/SubstraitPB/Options.h"
 
 using namespace mlir;
-using namespace mlir::iterators;
 using namespace mlir::substrait;
-using namespace mlir::tabular;
-using namespace mlir::tuple;
-
-//===----------------------------------------------------------------------===//
-// Iterators dialect and types
-//===----------------------------------------------------------------------===//
-
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Iterators, iterators, IteratorsDialect)
-
-bool mlirTypeIsAIteratorsStreamType(MlirType type) {
-  return unwrap(type).isa<StreamType>();
-}
-
-MlirType mlirIteratorsStreamTypeGet(MlirContext context, MlirType elementType) {
-  return wrap(StreamType::get(unwrap(context), unwrap(elementType)));
-}
 
 //===----------------------------------------------------------------------===//
 // Substrait dialect
@@ -86,45 +66,3 @@ MlirAttribute mlirSubstraitExportPlan(MlirOperation op,
   Attribute attr = StringAttr::get(context, str);
   return wrap(attr);
 }
-
-//===----------------------------------------------------------------------===//
-// Tabular dialect and types
-//===----------------------------------------------------------------------===//
-
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Tabular, tabular, TabularDialect)
-
-/// Checks whether the given type is a tabular view type.
-bool mlirTypeIsATabularView(MlirType type) {
-  return unwrap(type).isa<TabularViewType>();
-}
-
-/// Creates a tabular view type that consists of the given list of column types.
-/// The type is owned by the context.
-MlirType mlirTabularViewTypeGet(MlirContext ctx, intptr_t numColumns,
-                                MlirType const *columnTypes) {
-  SmallVector<Type, 4> types;
-  ArrayRef<Type> typesRef = unwrapList(numColumns, columnTypes, types);
-  return wrap(TabularViewType::get(unwrap(ctx), typesRef));
-}
-
-/// Returns the number of types contained in a tabular view.
-intptr_t mlirTabularViewTypeGetNumColumnTypes(MlirType type) {
-  return unwrap(type).cast<TabularViewType>().getColumnTypes().size();
-}
-
-/// Returns the pos-th type in the tabular view type.
-MlirType mlirTabularViewTypeGetColumnType(MlirType type, intptr_t pos) {
-  return wrap(unwrap(type)
-                  .cast<TabularViewType>()
-                  .getColumnTypes()[static_cast<size_t>(pos)]);
-}
-
-MlirType mlirTabularViewTypeGetRowType(MlirType type) {
-  return wrap(unwrap(type).cast<TabularViewType>().getRowType());
-}
-
-//===----------------------------------------------------------------------===//
-// Tuple dialect and attributes
-//===----------------------------------------------------------------------===//
-
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Tuple, tuple, TupleDialect)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,3 @@
 add_subdirectory(CAPI)
-add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Target)
-add_subdirectory(Utils)

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -1,4 +1,1 @@
-add_subdirectory(Iterators)
 add_subdirectory(Substrait)
-add_subdirectory(Tabular)
-add_subdirectory(Tuple)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,37 +14,10 @@ declare_mlir_python_sources(StructuredPythonSources.Dialects
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT StructuredPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
-  TD_FILE dialects/IteratorsOps.td
-  SOURCES
-  dialects/iterators.py
-  DIALECT_NAME iterators
-)
-
-declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT StructuredPythonSources.Dialects
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
   TD_FILE dialects/SubstraitOps.td
   SOURCES
   dialects/substrait.py
   DIALECT_NAME substrait
-)
-
-declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT StructuredPythonSources.Dialects
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
-  TD_FILE dialects/TabularOps.td
-  SOURCES
-  dialects/tabular.py
-  DIALECT_NAME tabular
-)
-
-declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT StructuredPythonSources.Dialects
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
-  TD_FILE dialects/TupleOps.td
-  SOURCES
-  dialects/tuple.py
-  DIALECT_NAME tuple
 )
 
 declare_mlir_python_extension(StructuredPythonSources.DialectExtension
@@ -54,22 +27,6 @@ declare_mlir_python_extension(StructuredPythonSources.DialectExtension
   StructuredDialects.cpp
   EMBED_CAPI_LINK_LIBS
   StructuredCAPI
-)
-
-declare_mlir_python_extension(StructuredPythonSources.PassesExtension
-  MODULE_NAME _mlirStructuredPasses
-  ADD_TO_PARENT StructuredPythonSources
-  SOURCES
-  StructuredPasses.cpp
-  EMBED_CAPI_LINK_LIBS
-  StructuredCAPI
-)
-
-declare_mlir_python_sources(StructuredPythonSources.ExecutionEngine
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
-  ADD_TO_PARENT StructuredPythonSources
-  SOURCES_GLOB
-    runtime/*.py
 )
 
 # ###############################################################################

--- a/python/StructuredDialects.cpp
+++ b/python/StructuredDialects.cpp
@@ -27,40 +27,6 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
 #endif
 
   //===--------------------------------------------------------------------===//
-  // Iterators dialect
-  //===--------------------------------------------------------------------===//
-  auto iteratorsModule = mainModule.def_submodule("iterators");
-
-  //
-  // Dialect
-  //
-
-  iteratorsModule.def(
-      "register_dialect",
-      [](MlirContext context, bool doLoad) {
-        MlirDialectHandle handle = mlirGetDialectHandle__iterators__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (doLoad) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context") = py::none(), py::arg("load") = true);
-
-  //
-  // Types
-  //
-
-  mlir_type_subclass(iteratorsModule, "StreamType",
-                     mlirTypeIsAIteratorsStreamType)
-      .def_classmethod(
-          "get",
-          [](const py::object &cls, MlirType elementType, MlirContext context) {
-            return cls(mlirIteratorsStreamTypeGet(context, elementType));
-          },
-          py::arg("cls"), py::arg("element_type"),
-          py::arg("context") = py::none());
-
-  //===--------------------------------------------------------------------===//
   // Substrait dialect.
   //===--------------------------------------------------------------------===//
   auto substraitModule = mainModule.def_submodule("substrait");
@@ -158,68 +124,4 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
       },
       py::arg("op"), py::arg("pretty") = false,
       "Export a Substrait plan into the JSON format");
-
-  //===--------------------------------------------------------------------===//
-  // Tabular dialect.
-  //===--------------------------------------------------------------------===//
-  auto tabularModule = mainModule.def_submodule("tabular");
-
-  //
-  // Dialect
-  //
-
-  tabularModule.def(
-      "register_dialect",
-      [](MlirContext context, bool doLoad) {
-        MlirDialectHandle handle = mlirGetDialectHandle__tabular__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (doLoad) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context") = py::none(), py::arg("load") = true);
-
-  //
-  // Types
-  //
-
-  mlir_type_subclass(tabularModule, "TabularViewType", mlirTypeIsATabularView)
-      .def_classmethod(
-          "get",
-          [](const py::object &cls, const py::list &columnTypeList,
-             MlirContext context) {
-            intptr_t num = py::len(columnTypeList);
-            // Mapping py::list to SmallVector.
-            llvm::SmallVector<MlirType, 4> columnTypes;
-            for (auto columnType : columnTypeList) {
-              columnTypes.push_back(columnType.cast<MlirType>());
-            }
-            return cls(
-                mlirTabularViewTypeGet(context, num, columnTypes.data()));
-          },
-          py::arg("cls"), py::arg("column_types"),
-          py::arg("context") = py::none())
-      .def("get_column_type", mlirTabularViewTypeGetColumnType, py::arg("pos"))
-      .def("get_num_column_types", mlirTabularViewTypeGetNumColumnTypes)
-      .def("get_row_type", mlirTabularViewTypeGetRowType);
-
-  //===--------------------------------------------------------------------===//
-  // Tuple dialect.
-  //===--------------------------------------------------------------------===//
-  auto tupleModule = mainModule.def_submodule("tuple");
-
-  //
-  // Dialect
-  //
-
-  tupleModule.def(
-      "register_dialect",
-      [](MlirContext context, bool doLoad) {
-        MlirDialectHandle handle = mlirGetDialectHandle__tuple__();
-        mlirDialectHandleRegisterDialect(handle, context);
-        if (doLoad) {
-          mlirDialectHandleLoadDialect(handle, context);
-        }
-      },
-      py::arg("context") = py::none(), py::arg("load") = true);
 }

--- a/tools/structured-lsp-server/structured-lsp-server.cpp
+++ b/tools/structured-lsp-server/structured-lsp-server.cpp
@@ -20,27 +20,11 @@
 #include "mlir/InitAllPasses.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
-#include "structured/Conversion/Passes.h"
-#include "structured/Dialect/Iterators/IR/Iterators.h"
-#include "structured/Dialect/Iterators/Transforms/Passes.h"
 #include "structured/Dialect/Substrait/IR/Substrait.h"
-#include "structured/Dialect/Tabular/IR/Tabular.h"
-#include "structured/Dialect/Tuple/IR/Tuple.h"
-#include "structured/Dialect/Tuple/Transforms/Passes.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Signals.h"
 
 using namespace mlir;
-
-static void registerIteratorDialects(DialectRegistry &registry) {
-  registry.insert<
-      // clang-format off
-      mlir::iterators::IteratorsDialect,
-      mlir::tabular::TabularDialect,
-      mlir::tuple::TupleDialect
-      // clang-format on
-      >();
-}
 
 static void registerSubstraitDialects(DialectRegistry &registry) {
   registry.insert<mlir::substrait::SubstraitDialect>();
@@ -54,14 +38,10 @@ int main(int argc, char **argv) {
 #endif
 
   registerAllPasses();
-  registerStructuredConversionPasses();
-  registerIteratorsPasses();
-  registerTuplePasses();
 
   DialectRegistry registry;
   registerAllDialects(registry);
   registerAllExtensions(registry);
-  registerIteratorDialects(registry);
   registerSubstraitDialects(registry);
 
   return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -16,14 +16,8 @@
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
-#include "structured/Conversion/Passes.h"
-#include "structured/Dialect/Iterators/IR/Iterators.h"
-#include "structured/Dialect/Iterators/Transforms/Passes.h"
 #include "structured/Dialect/Substrait/IR/Substrait.h"
 #include "structured/Dialect/Substrait/Transforms/Passes.h"
-#include "structured/Dialect/Tabular/IR/Tabular.h"
-#include "structured/Dialect/Tuple/IR/Tuple.h"
-#include "structured/Dialect/Tuple/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
@@ -33,16 +27,6 @@
 
 using namespace mlir;
 using namespace mlir::substrait;
-
-static void registerIteratorDialects(DialectRegistry &registry) {
-  registry.insert<
-      // clang-format off
-      mlir::iterators::IteratorsDialect,
-      mlir::tabular::TabularDialect,
-      mlir::tuple::TupleDialect
-      // clang-format on
-      >();
-}
 
 static void registerSubstraitDialects(DialectRegistry &registry) {
   registry.insert<mlir::substrait::SubstraitDialect>();
@@ -56,15 +40,11 @@ int main(int argc, char **argv) {
 #endif
 
   registerAllPasses();
-  registerStructuredConversionPasses();
-  registerIteratorsPasses();
   registerSubstraitPasses();
-  registerTuplePasses();
 
   DialectRegistry registry;
   registerAllDialects(registry);
   registerAllExtensions(registry);
-  registerIteratorDialects(registry);
   registerSubstraitDialects(registry);
 
   return failed(


### PR DESCRIPTION
This commit cleans up the files with boilerplate code imported from the original location of this project, the
[IREE LLVM sandbox](https://github.com/iree-org/iree-llvm-sandbox), by removing all references to the other sub-projects that were part of that repository, most notably, `add_subdirectory` and similar directives from CMake files and `include` statements and various registration mechanisms from C++ files. This brings the project into a state where it can be built and the test suite passes in CI.